### PR TITLE
fix: escrita rd e SaidaULA; assumindo arq Harvard de uma vez

### DIFF
--- a/LAB3/dev/Controle.v
+++ b/LAB3/dev/Controle.v
@@ -282,7 +282,7 @@ always @(posedge CLK or posedge RST) begin
          EscrevePC      <= 1'b0;
          EscrevePCCond  <= 1'b0;
          EscrevePCB     <= 1'b0;
-         IouD           <= 1'b1;
+         IouD           <= 1'b1;    // RegDado = MemData
          EscreveIR      <= 1'b0;
          LeMem          <= 1'b1;
          EscreveMem     <= 1'b0;
@@ -349,11 +349,11 @@ always @(posedge CLK or posedge RST) begin
          EscreveIR      <= 1'b0;
          LeMem          <= 1'b0;
          EscreveMem     <= 1'b0;
-         EscreveReg     <= 1'b1;
+         EscreveReg     <= 1'b0;
          
          OrigPC         <= 2'b00;
-         OrigRd         <= 2'b00;
          /*
+         OrigRd         <= 2'b00;
          OrigAULA       <= 2'b;
          OrigBULA       <= 2'b;
          opULA          <= 2'b;

--- a/LAB3/dev/Multiciclo.v
+++ b/LAB3/dev/Multiciclo.v
@@ -55,10 +55,13 @@ mux4sync muxOrigPC (
    .enable((EscrevePCCond && Zero) || EscrevePC), .entr0(ResULA), .entr1(SaidaULA),
    .sel(OrigPC),   .saida(PCEscrita)
 );
-mux4 muxOrigEnder (.enable(1), .entr0(PC),       .entr1(SaidaULA),                  .sel(IouD),     .saida(Endereco));
-mux4 muxOrigRd    (.enable(1), .entr0(SaidaULA), .entr1(PC),       .entr2(RegDado), .sel(OrigRd),   .saida(DadoEscrita));
-mux4 muxOrigA     (.enable(1), .entr0(PCBack),   .entr1(A),        .entr2(PC),      .sel(OrigAULA), .saida(AULA));
-mux4 muxOrigB     (.enable(1), .entr0(B),        .entr1(32'd4),    .entr2(Imm),     .sel(OrigBULA), .saida(BULA));
+mux4sync muxOrigRd (
+   .enable(1'b1), .entr0(SaidaULA), .entr1(PC), .entr2(RegDado),
+   .sel(OrigRd), .saida(DadoEscrita)
+);
+mux4 muxOrigEnder (.enable(1'b1), .entr0(PC),       .entr1(SaidaULA),                  .sel(IouD),     .saida(Endereco));
+mux4 muxOrigA     (.enable(1'b1), .entr0(PCBack),   .entr1(A),        .entr2(PC),      .sel(OrigAULA), .saida(AULA));
+mux4 muxOrigB     (.enable(1'b1), .entr0(B),        .entr1(32'd4),    .entr2(Imm),     .sel(OrigBULA), .saida(BULA));
 
 
 ControleMulti Controle (
@@ -79,7 +82,7 @@ ImmGen ImmGen (.iInstrucao(Instr), .oImm(Imm));
 BancoReg BancoReg (
    .iCLK(clockCPU), .iRST(reset), .iRegWrite(EscreveReg),
    .iReadRegister1(rs1), .iReadRegister2(rs2), .iWriteRegister(rd),
-   .iWriteData(DadoEscrita), .oReadData1(A), .oReadData2(B),
+   .iWriteData(DadoEscrita), .oReadData1(Dado1), .oReadData2(Dado2),
    .iRegDispSelect(regin), .oRegDisp(regout)
 );
 
@@ -95,6 +98,7 @@ initial begin
    PC     <= TEXT_ADDRESS;
    PCBack <= TEXT_ADDRESS;
    Instr  <= 32'b0;
+   estado <= 4'b0;
    regout <= 32'b0;
 end
 
@@ -104,9 +108,12 @@ always @(posedge clockCPU) begin //or posedge reset
       PC     <= TEXT_ADDRESS;
    else begin
       MemLeitura  <= Endereco[28] ? MemData : MemInstr;
-      RegDado     <= MemLeitura;
+      RegDado     <= MemData;
       
       PC       <= PCEscrita;
+      A        <= Dado1;
+      B        <= Dado2;
+      SaidaULA <= ResULA;
    end
 end
 
@@ -114,13 +121,12 @@ always @(*) begin
    if (reset) begin
       PCBack <= TEXT_ADDRESS;
       Instr  <= 32'b0;
-      regout <= 32'b0;
    end
    else begin
       if (EscrevePCB)
          PCBack   <= PC;
       if (EscreveIR)
-         Instr <= MemLeitura;
+         Instr <= MemInstr;
    end
 end
 

--- a/LAB3/instruções.md
+++ b/LAB3/instruções.md
@@ -14,9 +14,9 @@ nº endereço
 02 00400008 0001A303     # MAIN: lw      t1, 0(gp)               # t1: 0xFFFFFF0F
 03 0040000C 77700393     #       addi    t2, zero, 1911          # t2: 0x00000777
 04 00400010 007372B3     #       and     t0, t1, t2              # t0: 0x00000707
-05 00400004 007362B3     #       or      t0, t1, t2              # t0: 0xFFFFFF7F
-06 00400008 006382B3     #       add     t0, t2, t1              # t0: 0x00000686 (overflow)
-07 0040000C 406382B3     #       sub     t0, t2, t1              # t0: 0xFFFFF798
+05 00400014 007362B3     #       or      t0, t1, t2              # t0: 0xFFFFFF7F
+06 00400018 006382B3     #       add     t0, t2, t1              # t0: 0x00000686 (overflow)
+07 0040001C 406382B3     #       sub     t0, t2, t1              # t0: 0xFFFFF798
 08 00400020 007322B3     #       slt     t0, t1, t2              # t0: 0x00000001
 09 00400024 0063A2B3     #       slt     t0, t2, t1              # t0: 0x00000000
 10 00400028 00028663     #       beq     t0, zero, 12            # tomado, -> PULA
@@ -44,9 +44,9 @@ nº endereço instr        # decompilação                          # regs     
 02 00400008 0001A303     # MAIN: lw      t1, 0(gp)               # t1: 0xFFFFFF0F            # 7
 03 0040000C 77700393     #       addi    t2, zero, 1911          # t2: 0x00000777            # 5
 04 00400010 007372B3     #       and     t0, t1, t2              # t0: 0x00000707            # 5
-05 00400004 007362B3     #       or      t0, t1, t2              # t0: 0xFFFFFF7F            # 5
-06 00400008 006382B3     #       add     t0, t2, t1              # t0: 0x00000686 (overflow) # 5
-07 0040000C 406382B3     #       sub     t0, t2, t1              # t0: 0xFFFFF798            # 5
+05 00400014 007362B3     #       or      t0, t1, t2              # t0: 0xFFFFFF7F            # 5
+06 00400018 006382B3     #       add     t0, t2, t1              # t0: 0x00000686 (overflow) # 5
+07 0040001C 406382B3     #       sub     t0, t2, t1              # t0: 0xFFFFF798            # 5
 08 00400020 007322B3     #       slt     t0, t1, t2              # t0: 0x00000001            # 5
 09 00400024 0063A2B3     #       slt     t0, t2, t1              # t0: 0x00000000            # 5
 10 00400028 00028663     #       beq     t0, zero, 12            # tomado, -> PULA           # 4


### PR DESCRIPTION
- possivelmente o rd seria escrito errado sempre, pois DadoEscrita atualizava na subida de clock, mas BancoReg escreve apenas na descida de clock
- separei as saídas da memória logo pra facilitar minha vida. desculpa Von Neumann -outras paradas aí. tempo de menos e trabalho demais